### PR TITLE
Allow users in the gpio group to export and unexport GPIO pins

### DIFF
--- a/etc/udev/rules.d/80-gpio-noroot.rules
+++ b/etc/udev/rules.d/80-gpio-noroot.rules
@@ -5,6 +5,7 @@
 SUBSYSTEM=="gpio", GROUP="gpio", MODE="0660"
 SUBSYSTEM=="gpio*", PROGRAM="/bin/sh -c '\
 	chown -R root:gpio /sys/class/gpio && chmod -R 770 /sys/class/gpio;\
+	chown -R root:gpio /sys/class/gpio/*export && chmod -R 220 /sys/class/gpio/*export;\
 	chown -R root:gpio /sys/devices/virtual/gpio && chmod -R 770 /sys/devices/virtual/gpio;\
 	chown -R root:gpio /sys$devpath && chmod -R 770 /sys$devpath\
 '"


### PR DESCRIPTION
Without this one needs to be root to do it